### PR TITLE
Updated api version

### DIFF
--- a/cert-manager-issuers/Chart.yaml
+++ b/cert-manager-issuers/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager-issuers
-version: v0.0.4
+version: v0.0.5
 appVersion: v0.5.2
 description: A Helm chart for cert-manager issuers
 home: https://github.com/afirth/site-cluster

--- a/cert-manager-issuers/templates/issuers.yaml
+++ b/cert-manager-issuers/templates/issuers.yaml
@@ -3,7 +3,7 @@
 
 {{- range $issuer := .Values.issuers }}
 ---
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: {{ .kind }}
 metadata:
   name: {{ .name }}


### PR DESCRIPTION
API version has been updated within cert-manager. It is no longer valid to use `cert-manager.io/v1alpha1` and documentation recommends `cert-manager.io/v1alpha2`.

https://cert-manager.io/docs/concepts/issuer/
